### PR TITLE
Ci/edit issue title

### DIFF
--- a/.github/ISSUE_TEMPLATE/instructor-abbreviation.yml
+++ b/.github/ISSUE_TEMPLATE/instructor-abbreviation.yml
@@ -2,6 +2,9 @@ name: 'Add/Update Instructor Abbreviation'
 description: 'Template to add or update an instructor abbreviation with relevant details.'
 title: 'Add/Update Instructor Abbreviation: [Abbreviation]'
 labels: ['🧑‍🏫 instructor', 'documentation']
+assignees:
+  - yokeTH
+  - Thiraput01
 
 body:
   - type: input

--- a/.github/workflows/replace-abbreviation.yml
+++ b/.github/workflows/replace-abbreviation.yml
@@ -1,0 +1,46 @@
+name: Replace Abbreviation in Issue Title
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  update-title:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Replace [Abbreviation] in Title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const issueNumber = issue.number;
+            const title = issue.title;
+            const body = issue.body;
+
+            if (!title.includes("[Abbreviation]")) {
+              console.log("No [Abbreviation] placeholder in title.");
+              return;
+            }
+
+            const match = body.match(/### Abbreviation\s+\n(.+?)\n/);
+            if (!match) {
+              console.log("Abbreviation not found in body.");
+              return;
+            }
+
+            const abbreviation = match[1].trim();
+            const newTitle = title.replace("[Abbreviation]", abbreviation);
+
+            if (newTitle !== title) {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: issueNumber,
+                title: newTitle
+              });
+              console.log(`Updated title to: ${newTitle}`);
+            } else {
+              console.log("No change needed in title.");
+            }


### PR DESCRIPTION
This pull request introduces improvements to the workflow for managing instructor abbreviations in GitHub issues. The changes include the addition of assignees to the instructor abbreviation issue template and the creation of a new GitHub Actions workflow to automatically replace placeholders in issue titles with actual abbreviations.

### Updates to instructor abbreviation management:

* [`.github/ISSUE_TEMPLATE/instructor-abbreviation.yml`](diffhunk://#diff-0acb3e772c438834585b9c69a557f34cec948f6c0a9b02f2bb5024a22df7c478R5-R7): Added `yokeTH` and `Thiraput01` as default assignees for issues created using the instructor abbreviation template. This ensures the right individuals are assigned to handle these issues.

### Automation workflow:

* [`.github/workflows/replace-abbreviation.yml`](diffhunk://#diff-f8ba01e9316ce4a395c9ecfd1f98d41769763c60deff2e22d801746167f2a4b1R1-R46): Added a new GitHub Actions workflow named "Replace Abbreviation in Issue Title." This workflow listens for issue events (`opened` or `edited`) and automatically replaces the `[Abbreviation]` placeholder in the issue title with the corresponding abbreviation extracted from the issue body. This streamlines issue management and ensures titles are updated dynamically.